### PR TITLE
Add note on WEX renewal window

### DIFF
--- a/services/wex/README.md
+++ b/services/wex/README.md
@@ -26,3 +26,4 @@ The following pages hold additional information about the service.
 
 - [Activation and Expiration](activation_expiration.md)
 - [Background jobs](background_jobs.md)
+- [Renewal window](renewal_window.md)

--- a/services/wex/renewal_window.md
+++ b/services/wex/renewal_window.md
@@ -1,0 +1,37 @@
+# Renewal window
+
+The registration for a waste exemption lasts 3 years and then expires. Before it expires users have a 1 month window in which they can renew.
+
+> An establishment or undertaking can renew their registration at any time in the month prior to the renewal date (3 years from date of initial registration) up to the date that the existing registration becomes invalid.
+
+<sub>[Environmental Permitting Guidance - Exempt Waste Operations (page 23 paragraph 6.24)](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/69317/pb13631-ep2010exemptwaste.pdf)</sub>
+
+Before the release of our renewal feature the service did not support 'renewing'. Users had to re-register using the same details. With the release users can create a new registration populated from the previous one. They can only do this if it's within the **renewal window**.
+
+## Before expiry window
+
+The guidance states users have  1 month to renew a registration before it expires. The service interprets this as 28 days. The team and business agreed on this decision based
+
+- it simplifies the code
+- it makes it consistent and fair for all users
+
+That last point refers to the fact that a month can be anything between 28 and 31 days long. So when you register could determine if you have more or less time than other users to renew.
+
+## After expiry window
+
+This is the period of time after a registration expires that a user can still renew it. It is often referred to as the **grace** window. There is nothing in the guidance or regulations that states we should or will provide it. But research with users and experience with renewals on [Waste Carriers](/services/wcr/grace_window.md) has shown it's required.
+
+The service interprets this as 30 days. The team and the business agreed this period.
+
+## Example
+
+An exemption that is **ACTIVE** on 22 Jan 2017 at 14:35 is officially
+
+- active from `00:00 22 Jan 2017`
+- expires at `24:00 21 Jan 2020`
+- is expired at `00:00 22 Jan 2020`
+
+The renewal windows are
+
+- can be renewed from `00:00 24 Dec 2019`
+- can no longer be renewed from `24:00 20 Feb 2020`

--- a/services/wex/renewal_window.md
+++ b/services/wex/renewal_window.md
@@ -25,7 +25,7 @@ The service interprets this as 30 days. The team and the business agreed this pe
 
 ## Example
 
-An exemption that is **ACTIVE** on 22 Jan 2017 at 14:35 is officially
+An exemption that is made **ACTIVE** on 22 Jan 2017 at 14:35 is officially
 
 - active from `00:00 22 Jan 2017`
 - expires at `24:00 21 Jan 2020`

--- a/services/wex/renewal_window.md
+++ b/services/wex/renewal_window.md
@@ -10,7 +10,7 @@ Before the release of our renewal feature the service did not support 'renewing'
 
 ## Before expiry window
 
-The guidance states users have  1 month to renew a registration before it expires. The service interprets this as 28 days. The team and business agreed on this decision based
+The guidance states users have 1 month to renew a registration before it expires. The service interprets this as 28 days. The team and business agreed on this decision because
 
 - it simplifies the code
 - it makes it consistent and fair for all users


### PR DESCRIPTION
With the launch of the WEX renewals feature imminent, this change adds a note that provides an explanation and example for the renewal windows used in Waste Exemptions.