### PR TITLE
Remove -ta from WEX back office repo link

### DIFF
--- a/services/wex/README.md
+++ b/services/wex/README.md
@@ -9,7 +9,7 @@ To quote the intro on the projects README.
 The service itself is built from 3 different repositories
 
 - [Waste exemptions front office](https://github.com/DEFRA/waste-exemptions-front-office)
-- [Waste exemptions back office](https://github.com/DEFRA/waste-exemptions-back-office-ta)
+- [Waste exemptions back office](https://github.com/DEFRA/waste-exemptions-back-office)
 - [Waste exemptions engine](https://github.com/DEFRA/waste-exemptions-engine)
 
 ## History


### PR DESCRIPTION
We finally archived the old waste-exemptions-back-office, which meant we could rename the technical alignment version to take over the name.

This just updates the link to the repo to reflect the name change.