### PR TITLE
Replace references to `master` with `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A team of awesome furicorns 🦄 dedicated to supporting and improving all Defra digital services built using *Ruby* ❤️ ('cos it's the best)!
 
-This acts as a repo of guides and documents specific to the team, plus its where we manage our master list of issues rather than trying to manage them in individual projects.
+This acts as a repo of guides and documents specific to the team, plus its where we manage our list of issues rather than trying to manage them in individual projects.
 
 ## Contents
 

--- a/services/wcr/background_jobs.md
+++ b/services/wcr/background_jobs.md
@@ -1,6 +1,6 @@
 # Background jobs
 
-The [Waste Carriers Back Office](https://github.com/DEFRA/waste-carriers-back-office) contains 3 background jobs which are run on a nightly schedule. The schedules are set in [schedule.rb](https://github.com/DEFRA/waste-carriers-back-office/blob/master/config/schedule.rb).
+The [Waste Carriers Back Office](https://github.com/DEFRA/waste-carriers-back-office) contains 3 background jobs which are run on a nightly schedule. The schedules are set in [schedule.rb](https://github.com/DEFRA/waste-carriers-back-office/blob/main/config/schedule.rb).
 
 The schedule is used to create and update [cron](https://en.wikipedia.org/wiki/Cron) jobs (the actual create and update occurs during deployment with [Capistrano](https://capistranorb.com/)). This is implemented using the [whenever gem](https://github.com/javan/whenever).
 

--- a/services/wcr/migrations.md
+++ b/services/wcr/migrations.md
@@ -4,7 +4,7 @@
 
 Because the service does not talk to the database directly using something like ActiveRecord, any migrations have to be written and added to the project manually.
 
-We use [rake](https://github.com/ruby/rake) to write and execute any data migrations. These should be added to the namespace `data_migration` and you can find the ones below in the [data_migration.rake](https://github.com/DEFRA/waste-carriers-frontend/blob/master/lib/tasks/data_migration.rake) task
+We use [rake](https://github.com/ruby/rake) to write and execute any data migrations. These should be added to the namespace `data_migration` and you can find the ones below in the [data_migration.rake](https://github.com/DEFRA/waste-carriers-frontend/blob/main/lib/tasks/data_migration.rake) task
 
 ## Phase 1 registrations
 
@@ -18,7 +18,7 @@ In this case the migration of phase 1 registrations involved nothing more than a
 
 ## Multiple addresses
 
-Release [to be confirmed](https://github.com/DEFRA/waste-exemplar-frontend) included changes to the registration model so that address details are now held in a model called [address](https://github.com/DEFRA/waste-carriers-frontend/blob/master/app/models/address.rb) which sits in an Ohm [Set](http://www.rubydoc.info/github/soveran/ohm/Ohm/Set) on the registration.
+Release [to be confirmed](https://github.com/DEFRA/waste-exemplar-frontend) included changes to the registration model so that address details are now held in a model called [address](https://github.com/DEFRA/waste-carriers-frontend/blob/main/app/models/address.rb) which sits in an Ohm [Set](http://www.rubydoc.info/github/soveran/ohm/Ohm/Set) on the registration.
 
 The migration script copies the values held on against the root of existing registrations in a new address sub-document held in an array called `addresses`.
 

--- a/services/wcr/preparing_for_a_release.md
+++ b/services/wcr/preparing_for_a_release.md
@@ -41,7 +41,7 @@ All applications and the engine should have a CHANGELOG, which is updated with e
 
 You must create the version tag before you update the CHANGELOG (the only exception to this is the engine).
 
-To update the changelog, make sure you are on the master branch, and then run the following:
+To update the changelog, make sure you are on the `main` branch, and then run the following:
 
 - `bundle install`
 - `bundle exec rake changelog`

--- a/services/wex/background_jobs.md
+++ b/services/wex/background_jobs.md
@@ -1,6 +1,6 @@
 # Background jobs
 
-The [Waste Exemptions Back office](https://github.com/DEFRA/waste-exemptions-back-office-ta) contains 3 background jobs which are run on a nightly schedule. The schedules are set in [schedule.rb](https://github.com/DEFRA/waste-exemptions-back-office-ta/blob/master/config/schedule.rb).
+The [Waste Exemptions Back office](https://github.com/DEFRA/waste-exemptions-back-office-ta) contains 3 background jobs which are run on a nightly schedule. The schedules are set in [schedule.rb](https://github.com/DEFRA/waste-exemptions-back-office-ta/blob/main/config/schedule.rb).
 
 The schedule is used to create and update [cron](https://en.wikipedia.org/wiki/Cron) jobs (the actual create and update occurs during deployment with [Capistrano](https://capistranorb.com/)). This is implemented using the [whenever gem](https://github.com/javan/whenever).
 


### PR DESCRIPTION
This change will focus on just updating any references. A subsequent PR will add a comment to our documents covering why we use `main` instead of `master`.